### PR TITLE
fix: incorrect docs keybinds, misleading behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ Using lazy.nvim:
             -- custom settings here
             -- e.g. hide_cursor = false
         })
-        vim.keymap.set("n", ",s", ":Symbols<CR>")
-        vim.keymap.set("n", ",S", ":SymbolsClose<CR>")
+        vim.keymap.set("n", ",s", "<cmd> Symbols<CR>")
+        vim.keymap.set("n", ",S", "<cmd> SymbolsClose<CR>")
     end
 }
 ```


### PR DESCRIPTION
Typically, when mapping commands, `<cmd>` should be used since it just executes the command. Whereas using `:` causes neovim to enter command mode.