### PR TITLE
fix: use the "officially" defined lsp method name

### DIFF
--- a/lua/symbols/providers.lua
+++ b/lua/symbols/providers.lua
@@ -77,7 +77,7 @@ end
 ---@param buf integer
 ---@return boolean
 function LspProvider:supports(buf)
-    local clients = vim.lsp.get_clients({ bufnr = buf, method = "documentSymbolProvider" })
+    local clients = vim.lsp.get_clients({ bufnr = buf, method = vim.lsp.protocol.Methods.textDocument_documentSymbol })
     self.client = clients[1]
     return #clients > 0
 end
@@ -119,7 +119,7 @@ function LspProvider:async_get_symbols(buf, refresh_symbols, on_fail, on_timeout
     end
 
     local params = { textDocument = vim.lsp.util.make_text_document_params(buf), }
-    local ok, request_id = self.client.request("textDocument/documentSymbol", params, handler)
+    local ok, request_id = self.client.request(vim.lsp.protocol.Methods.textDocument_documentSymbol, params, handler)
     if not ok then on_fail() end
 
     vim.defer_fn(


### PR DESCRIPTION
Replace "documentSymbolProvider" and "textDocument/documentSymbol" with `vim.lsp.protocol.Methods.textDocument_documentSymbol`

the `LspProvider:supports(buf)` incorrectly calls `vim.lsp.get_clients({ bufnr = buf, method = "documentSymbolProvider" })`. This returns all servers regardless of the filter string (we should probably report it to the neovim team) due to the method name being incorrect. Because of this, `symbols.nvim` constantly selects `typos_lsp` in my config as the document symbol provider.

The `vim.lsp.protocol.Methods.textDocument_documentSymbol` is defined here:
https://github.com/neovim/neovim/blob/af112e605d4d8f3015744b69ec7544d732f8dad9/runtime/lua/vim/lsp/protocol.lua#L865