### PR TITLE
Some minor changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,9 @@ Default config below.
         -- When enabled every symbol will be automatically peeked after cursor
         -- movement.
         auto_peek = false,
+        -- Whether the sidebar should unfold the target buffer on goto
+        -- This simply sends a zv after the zz
+        unfold_on_goto = false,
         -- Whether to close the sidebar on goto symbol.
         close_on_goto = false,
         -- Whether the sidebar should wrap text.
@@ -236,6 +239,8 @@ Default config below.
             guide_vert = "│",
             guide_middle_item = "├",
             guide_last_item = "└",
+            -- use this highlight group for the guide lines
+            hl = "Comment"
         },
         -- Config for the preview window.
         preview = {

--- a/README.md
+++ b/README.md
@@ -387,6 +387,39 @@ Default config below.
 }
 ```
 
+# API
+
+There is now a (currently very simple) API available to control the Sidebar from LUA
+
+```lua
+  ---perform any action defined in SidebarAction
+  ---@param act SidebarAction[]
+  action = function(act)
+    local sidebar = apisupport_getsidebar()
+    if sidebar ~= nil and sidebar_actions[act] ~= nil then
+      sidebar_actions[act](sidebar)
+    end
+  end,
+  ---manually refresh the symbols in the current sidebar
+  refresh_symbols = function()
+    local sidebar = apisupport_getsidebar()
+    if sidebar ~= nil then
+      sidebar:refresh_symbols()
+    end
+  end
+```
+The available actions can be obtained by calling
+
+```lua
+=require("symbols.config").SidebarAction
+```
+
+For example, to unfold the entire tree you would call:
+
+```lua
+require("symbols").api.action("unfold-all")
+```
+
 # Alternatives
 
 - [aerial.nvim](https://github.com/stevearc/aerial.nvim)

--- a/doc/symbols.txt
+++ b/doc/symbols.txt
@@ -224,6 +224,9 @@ Default config below.
             -- When enabled every symbol will be automatically peeked after cursor
             -- movement.
             auto_peek = false,
+            -- Whether the sidebar should unfold the target buffer on goto
+            -- This simply sends a zv after the zz
+            unfold_on_goto = false,
             -- Whether to close the sidebar on goto symbol.
             close_on_goto = false,
             -- Whether the sidebar should wrap text.
@@ -236,6 +239,8 @@ Default config below.
                 guide_vert = "│",
                 guide_middle_item = "├",
                 guide_last_item = "└",
+                -- use this highlight group for the guide lines
+                hl = "Comment"
             },
             -- Config for the preview window.
             preview = {

--- a/lua/symbols/config.lua
+++ b/lua/symbols/config.lua
@@ -6,6 +6,7 @@ local M = {}
 ---@field guide_vert string
 ---@field guide_middle_item string
 ---@field guide_last_item string
+---@field hl string
 
 ---@enum SidebarAction
 M.SidebarAction = {
@@ -99,6 +100,7 @@ M.OpenDirection = {
 ---@field show_guide_lines boolean
 ---@field auto_peek boolean
 ---@field close_on_goto boolean
+---@field unfold_on_goto boolean
 ---@field wrap boolean
 ---@field chars CharConfig
 ---@field preview PreviewConfig
@@ -157,12 +159,14 @@ M.default = {
         auto_peek = false,
         close_on_goto = false,
         wrap = false,
+        unfold_on_goto = false,
         chars = {
             folded = "",
             unfolded = "",
             guide_vert = "│",
             guide_middle_item = "├",
             guide_last_item = "└",
+            hl = "Comment"
         },
         preview = {
             show_always = false,

--- a/lua/symbols/init.lua
+++ b/lua/symbols/init.lua
@@ -1,3 +1,4 @@
+-- vim: ts=4:sw=4:set et
 local cfg = require("symbols.config")
 local utils = require("symbols.utils")
 local log = require("symbols.log")
@@ -2890,24 +2891,25 @@ function M.setup(...)
 end
 
 local apisupport_getsidebar = function()
-  local win = vim.api.nvim_get_current_win()
-  local sidebar = find_sidebar_for_win(sidebars, win)
-  return sidebar
+    local win = vim.api.nvim_get_current_win()
+    local sidebar = find_sidebar_for_win(sidebars, win)
+    return sidebar
 end
 
 M.api = {
-  action = function(act)
-    local sidebar = apisupport_getsidebar()
-    if sidebar ~= nil and sidebar_actions[act] ~= nil then
-      sidebar_actions[act](sidebar)
+    action = function(act)
+        vim.validate({ act = { act, "string" } })
+        local sidebar = apisupport_getsidebar()
+        if sidebar ~= nil and sidebar_actions[act] ~= nil then
+            sidebar_actions[act](sidebar)
+        end
+    end,
+    refresh_symbols = function()
+        local sidebar = apisupport_getsidebar()
+        if sidebar ~= nil then
+            sidebar:refresh_symbols()
+        end
     end
-  end,
-  refresh_symbols = function()
-    local sidebar = apisupport_getsidebar()
-    if sidebar ~= nil then
-      sidebar:refresh_symbols()
-    end
-  end
 }
 
 return M

--- a/lua/symbols/init.lua
+++ b/lua/symbols/init.lua
@@ -1628,13 +1628,15 @@ local function sidebar_get_buf_lines_and_highlights(symbols, chars, show_guide_l
                 else
                     prefix = chars.unfolded .. " "
                 end
-                local highlight = nvim.Highlight:new({
-                  group = chars.hl,
-                  line = line_nr,
-                  col_start = #indent,
-                  col_end = #indent + 1
-                })
-                table.insert(highlights, highlight)
+                if show_guide_lines then
+                    local highlight = nvim.Highlight:new({
+                      group = chars.hl,
+                      line = line_nr,
+                      col_start = #indent,
+                      col_end = #indent + 1
+                    })
+                    table.insert(highlights, highlight)
+                end
                 local kind_display = cfg.kind_for_symbol(kinds_display_config, sym, kinds_default_config)
                 local line = indent .. prefix .. (kind_display ~= "" and (kind_display .. " ") or "") .. sym.name
                 table.insert(buf_lines, line)
@@ -1651,13 +1653,15 @@ local function sidebar_get_buf_lines_and_highlights(symbols, chars, show_guide_l
                 else
                     new_indent = indent .. "  "
                 end
-                local hl = nvim.Highlight:new({
-                  group = chars.hl,
-                  line = line_nr,
-                  col_start = 1,
-                  col_end = #indent + 1
-                })
-                table.insert(highlights, hl)
+                if show_guide_lines then
+                    local hl = nvim.Highlight:new({
+                      group = chars.hl,
+                      line = line_nr,
+                      col_start = 1,
+                      col_end = #indent + 1
+                    })
+                    table.insert(highlights, hl)
+                end
                 line_nr = get_buf_lines_and_highlights(sym, new_indent, line_nr + 1)
             end
         end

--- a/lua/symbols/init.lua
+++ b/lua/symbols/init.lua
@@ -109,7 +109,7 @@ function Preview:goto_symbol()
     local cursor = vim.api.nvim_win_get_cursor(self.win)
     vim.api.nvim_win_set_cursor(self.sidebar.source_win, cursor)
     vim.api.nvim_set_current_win(self.sidebar.source_win)
-    vim.fn.win_execute(self.sidebar.source_win, "normal! zz")
+    vim.fn.win_execute(self.sidebar.source_win, self.sidebar.unfold_on_goto and "normal! zz zv" or "normal! zz")
     if self.sidebar.close_on_goto then
         self.sidebar:close()
     end
@@ -1104,7 +1104,7 @@ function SearchView:jump_to_current_symbol()
         { symbol.range.start.line + 1, symbol.range.start.character }
     )
     vim.api.nvim_set_current_win(self.sidebar.source_win)
-    vim.fn.win_execute(self.sidebar.source_win, "normal! zz")
+    vim.fn.win_execute(self.sidebar.source_win, self.sidebar.unfold_on_goto and "normal! zz zv" or "normal! zz")
     flash_highlight_under_cursor(self.sidebar.source_win, 400, 1)
 end
 
@@ -1183,6 +1183,7 @@ end
 ---@field show_inline_details boolean
 ---@field show_guide_lines boolean
 ---@field wrap boolean
+---@field unfold_on_goto boolean
 ---@field auto_resize AutoResizeConfig
 ---@field fixed_width integer
 ---@field keymaps KeymapsConfig
@@ -1221,6 +1222,7 @@ function Sidebar:new()
         show_inline_details = false,
         show_guide_lines = false,
         wrap = false,
+        unfold_on_goto = config.unfold_on_goto,
         auto_resize = vim.deepcopy(config.auto_resize, true),
         fixed_width = config.fixed_width,
         keymaps = config.keymaps,
@@ -1471,6 +1473,9 @@ function Sidebar:open()
             signcolumn = "no",
             cursorline = true,
             winfixwidth = true,
+            foldcolumn = "0",
+            statuscolumn = "",
+            listchars = "eol: ",
             wrap = self.wrap,
         }
     )
@@ -1623,6 +1628,13 @@ local function sidebar_get_buf_lines_and_highlights(symbols, chars, show_guide_l
                 else
                     prefix = chars.unfolded .. " "
                 end
+                local highlight = nvim.Highlight:new({
+                  group = chars.hl,
+                  line = line_nr,
+                  col_start = #indent,
+                  col_end = #indent + 1
+                })
+                table.insert(highlights, highlight)
                 local kind_display = cfg.kind_for_symbol(kinds_display_config, sym, kinds_default_config)
                 local line = indent .. prefix .. (kind_display ~= "" and (kind_display .. " ") or "") .. sym.name
                 table.insert(buf_lines, line)
@@ -1639,6 +1651,13 @@ local function sidebar_get_buf_lines_and_highlights(symbols, chars, show_guide_l
                 else
                     new_indent = indent .. "  "
                 end
+                local hl = nvim.Highlight:new({
+                  group = chars.hl,
+                  line = line_nr,
+                  col_start = 1,
+                  col_end = #indent + 1
+                })
+                table.insert(highlights, hl)
                 line_nr = get_buf_lines_and_highlights(sym, new_indent, line_nr + 1)
             end
         end
@@ -1949,7 +1968,7 @@ function Sidebar:_goto_symbol()
         { symbol.range.start.line + 1, symbol.range.start.character }
     )
     if ok then
-        vim.fn.win_execute(self.source_win, "normal! zz")
+        vim.fn.win_execute(self.source_win, self.unfold_on_goto and "normal! zz zv" or "normal! zz")
         flash_highlight_under_cursor(self.source_win, 400, 1)
     else
         log.warn(err)
@@ -2438,6 +2457,7 @@ local function sidebar_new(sidebar, symbols_retriever, num, config, gs, debug)
     sidebar.cursor_follow = config.cursor_follow
     sidebar.auto_peek = config.auto_peek
     sidebar.close_on_goto = config.close_on_goto
+    sidebar.unfold_on_goto = config.unfold_on_goto
 
     sidebar.buf = vim.api.nvim_create_buf(false, true)
     nvim.buf_set_modifiable(sidebar.buf, false)
@@ -2841,6 +2861,9 @@ local function setup_autocommands(gs, sidebars, symbols_retriever)
     )
 end
 
+---@type Sidebar[]
+local sidebars = {}
+
 function M.setup(...)
     local config = cfg.prepare_config(...)
 
@@ -2857,12 +2880,30 @@ function M.setup(...)
     }
     local symbols_retriever = SymbolsRetriever_new(providers, config.providers)
 
-    ---@type Sidebar[]
-    local sidebars = {}
-
     if config.dev.enabled then setup_dev(gs, sidebars, config) end
     setup_user_commands(gs, sidebars, symbols_retriever, config)
     setup_autocommands(gs, sidebars, symbols_retriever)
 end
+
+local apisupport_getsidebar = function()
+  local win = vim.api.nvim_get_current_win()
+  local sidebar = find_sidebar_for_win(sidebars, win)
+  return sidebar
+end
+
+M.api = {
+  action = function(act)
+    local sidebar = apisupport_getsidebar()
+    if sidebar ~= nil then
+      sidebar_actions[act](sidebar)
+    end
+  end,
+  refresh_symbols = function()
+    local sidebar = apisupport_getsidebar()
+    if sidebar ~= nil then
+      sidebar:refresh_symbols()
+    end
+  end
+}
 
 return M

--- a/lua/symbols/init.lua
+++ b/lua/symbols/init.lua
@@ -2898,7 +2898,7 @@ end
 M.api = {
   action = function(act)
     local sidebar = apisupport_getsidebar()
-    if sidebar ~= nil then
+    if sidebar ~= nil and sidebar_actions[act] ~= nil then
       sidebar_actions[act](sidebar)
     end
   end,


### PR DESCRIPTION
Hi

I recently found this plugin and integrated it into my personal Neovim config. It's a very good alternative to the better known Outline plugin. In my tests it seems to be much faster than Outline and has a good fuzzy search feature, which is great.

There are a few minor things which I would like to contribute. I use folding quite a lot and I believe, the symbol picker should make sure the target symbols is visible. This is very simple to do with `zv` which will open all folds necessary to reveal the target line.

The highlight group for the guide lines is just a minor visual change.

### The following things are added or changed

- added option `unfold_on_goto`. This will send a `zv` after the `zz` to open any folds that may hide the target symbol in the associated buffer.

- added a highlight group setting to `CharsConfig`. This will be used to set the highlight group for the guide lines to allow a consistent look with other plugins like NvimTree/NeoTree and various picker plugins.

- added some window options when opening the sidebar to hide foldcolumn, statuscolumn and some listchars. This will remove any unnecessary padding on the left side of the sidebar.

- added a very simple api that allows to execute sidebar actions via lua calls. E.g.`require("symbols").api.action("unfold-all")` which is great to have as a keybind.

