### PR TITLE
highlight groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,8 +214,13 @@ Default config below.
             guide_middle_item = "├",
             guide_last_item = "└",
             -- use this highlight group for the guide lines
-            hl = "Comment"
+            hl_guides = "Comment",
+            -- use this highlight group for the collapse/expand markers
+            hl_foldmarker = "String"
         },
+        -- highlight group for the inline details shown next to the symbol name
+        -- (provider - dependent)
+        hl_details = "Comment",
         -- Config for the preview window.
         preview = {
             -- Whether the preview window is always opened when the sidebar is
@@ -369,6 +374,7 @@ There is now a (currently very simple) API available to control the Sidebar from
   ---perform any action defined in SidebarAction
   ---@param act SidebarAction[]
   action = function(act)
+    vim.validate({ act = { act, "string" } })
     local sidebar = apisupport_getsidebar()
     if sidebar ~= nil and sidebar_actions[act] ~= nil then
       sidebar_actions[act](sidebar)

--- a/lua/symbols/config.lua
+++ b/lua/symbols/config.lua
@@ -6,7 +6,8 @@ local M = {}
 ---@field guide_vert string
 ---@field guide_middle_item string
 ---@field guide_last_item string
----@field hl string
+---@field hl_guides string
+---@field hl_foldmarker string
 
 ---@enum SidebarAction
 M.SidebarAction = {
@@ -105,6 +106,7 @@ M.OpenDirection = {
 ---@field chars CharConfig
 ---@field preview PreviewConfig
 ---@field keymaps KeymapsConfig
+---@field hl_details string
 
 ---@class SymbolDisplayConfig
 ---@field kind string?
@@ -160,13 +162,15 @@ M.default = {
         close_on_goto = false,
         wrap = false,
         unfold_on_goto = false,
+        hl_details = "Comment",
         chars = {
             folded = "",
             unfolded = "",
             guide_vert = "│",
             guide_middle_item = "├",
             guide_last_item = "└",
-            hl = "Comment"
+            hl_guides = "Comment",
+            hl_foldmarker = "Operator"
         },
         preview = {
             show_always = false,

--- a/lua/symbols/init.lua
+++ b/lua/symbols/init.lua
@@ -1208,6 +1208,7 @@ end
 ---@field show_guide_lines boolean
 ---@field wrap boolean
 ---@field unfold_on_goto boolean
+---@field hl_details string
 ---@field auto_resize AutoResizeConfig
 ---@field fixed_width integer
 ---@field keymaps KeymapsConfig
@@ -1249,6 +1250,7 @@ function Sidebar:new()
         show_guide_lines = false,
         wrap = false,
         unfold_on_goto = config.unfold_on_goto,
+        hl_details = config.hl_details,
         auto_resize = vim.deepcopy(config.auto_resize, true),
         fixed_width = config.fixed_width,
         keymaps = config.keymaps,
@@ -1781,15 +1783,17 @@ local function get_display_lines(ctx, line_nr, symbol, recurse)
 
         if state.visible_children > 0 then
             if ctx.show_guide_lines then
-                local hl = nvim.Highlight:new({ group = ctx.chars.hl, line = line_nr + #result.lines, col_start = 1, col_end = line_len })
+                local hl = nvim.Highlight:new({ group = ctx.chars.hl_guides, line = line_nr + #result.lines, col_start = 1, col_end = line_len })
                 table.insert(result.highlights, hl)
             end
             line_add(((state.folded and ctx.chars.folded) or ctx.chars.unfolded) .. " ")
+            local hltop = nvim.Highlight:new({ group = ctx.chars.hl_foldmarker, line = line_nr + #result.lines, col_start = 0, col_end = line_len })
+            table.insert(result.highlights, hltop)
         elseif ctx.show_guide_lines and symbol.level > 1 then
             line_add(
                 ((symbol_is_last_child(symbol) and ctx.chars.guide_last_item) or ctx.chars.guide_middle_item) .. " "
             )
-            local hl = nvim.Highlight:new({ group = ctx.chars.hl, line = line_nr + #result.lines, col_start = 1, col_end = line_len })
+            local hl = nvim.Highlight:new({ group = ctx.chars.hl_guides, line = line_nr + #result.lines, col_start = 1, col_end = line_len })
             table.insert(result.highlights, hl)
         else
             local space = (symbol.level == 1 and ctx.using_folds) and "  " or " "
@@ -1851,12 +1855,12 @@ end
 ---@param buf integer
 ---@param start_line integer zero-indexed
 ---@param details string[]
-local function buf_add_inline_details(buf, start_line, details)
+local function buf_add_inline_details(buf, start_line, details, hl)
     for line, detail in ipairs(details) do
         vim.api.nvim_buf_set_extmark(
             buf, SIDEBAR_EXT_NS, start_line + line - 1, -1,
             {
-                virt_text = { { detail, "Comment" } },
+                virt_text = { { detail, hl or "Comment" } },  -- TODO: hl group for inline text
                 virt_text_pos = "eol",
                 hl_mode = "combine",
             }
@@ -1873,7 +1877,7 @@ function Sidebar:refresh_view()
     vim.api.nvim_buf_clear_namespace(self.buf, SIDEBAR_EXT_NS, 0, -1)
     nvim.buf_set_content(self.buf, result.lines)
     buf_add_highlights(self.buf, result.highlights)
-    buf_add_inline_details(self.buf, 0, result.inline_details)
+    buf_add_inline_details(self.buf, 0, result.inline_details, self.hl_details)
 
     self:refresh_size()
 end
@@ -2104,7 +2108,7 @@ function Sidebar:set_cursor_at_symbol(target, unfold)
         nvim.buf_set_modifiable(self.buf, false)
 
         buf_add_highlights(self.buf, result.highlights)
-        buf_add_inline_details(self.buf, top_level_ancestor_line-1, result.inline_details)
+        buf_add_inline_details(self.buf, top_level_ancestor_line-1, result.inline_details, self.hl_details)
     end
 
     nvim.win_set_cursor(self.win, current_line, 0)
@@ -2251,7 +2255,7 @@ function Sidebar:_unfold(symbol, symbol_line)
     nvim.buf_set_modifiable(self.buf, false)
 
     buf_add_highlights(self.buf, result.highlights)
-    buf_add_inline_details(self.buf, symbol_line-1, result.inline_details)
+    buf_add_inline_details(self.buf, symbol_line-1, result.inline_details, self.hl_details)
 
     self:set_cursor_at_symbol(symbol, false)
     self:schedule_refresh_size()
@@ -2282,7 +2286,7 @@ function Sidebar:_fold(symbol, symbol_line, symbol_line_count)
     nvim.buf_set_modifiable(self.buf, false)
 
     buf_add_highlights(self.buf, result.highlights)
-    buf_add_inline_details(self.buf, symbol_line-1, result.inline_details)
+    buf_add_inline_details(self.buf, symbol_line-1, result.inline_details, self.hl_details)
 
     self:set_cursor_at_symbol(symbol, false)
     self:schedule_refresh_size()
@@ -2323,7 +2327,7 @@ function Sidebar:unfold_recursively()
     nvim.buf_set_modifiable(self.buf, false)
 
     buf_add_highlights(self.buf, result.highlights)
-    buf_add_inline_details(self.buf, cursor_line-1, result.inline_details)
+    buf_add_inline_details(self.buf, cursor_line-1, result.inline_details, self.hl_details)
 
     self:set_cursor_at_symbol(symbol, false)
     self:schedule_refresh_size()
@@ -2451,7 +2455,7 @@ function Sidebar:toggle_details()
         local ctx = DisplayContext:new(self)
         local symbols = self:current_symbols()
         local details = get_inline_details(ctx, symbols.root, true)
-        buf_add_inline_details(self.buf, 0, details)
+        buf_add_inline_details(self.buf, 0, details, self.hl_details)
     else
         buf_clear_inline_details(self.buf, 0, -1)
     end
@@ -2740,6 +2744,7 @@ local function sidebar_new(sidebar, symbols_retriever, num, config, gs, debug)
     sidebar.auto_peek = config.auto_peek
     sidebar.close_on_goto = config.close_on_goto
     sidebar.unfold_on_goto = config.unfold_on_goto
+    sidebar.hl_details = config.hl_details
 
     sidebar.buf = vim.api.nvim_create_buf(false, true)
     nvim.buf_set_modifiable(sidebar.buf, false)

--- a/lua/symbols/init.lua
+++ b/lua/symbols/init.lua
@@ -1860,7 +1860,7 @@ local function buf_add_inline_details(buf, start_line, details, hl)
         vim.api.nvim_buf_set_extmark(
             buf, SIDEBAR_EXT_NS, start_line + line - 1, -1,
             {
-                virt_text = { { detail, hl or "Comment" } },  -- TODO: hl group for inline text
+                virt_text = { { detail, hl } },
                 virt_text_pos = "eol",
                 hl_mode = "combine",
             }

--- a/lua/symbols/init.lua
+++ b/lua/symbols/init.lua
@@ -1786,8 +1786,9 @@ local function get_display_lines(ctx, line_nr, symbol, recurse)
                 local hl = nvim.Highlight:new({ group = ctx.chars.hl_guides, line = line_nr + #result.lines, col_start = 1, col_end = line_len })
                 table.insert(result.highlights, hl)
             end
+            local fm_col_pos = line_len
             line_add(((state.folded and ctx.chars.folded) or ctx.chars.unfolded) .. " ")
-            local hltop = nvim.Highlight:new({ group = ctx.chars.hl_foldmarker, line = line_nr + #result.lines, col_start = 0, col_end = line_len })
+            local hltop = nvim.Highlight:new({ group = ctx.chars.hl_foldmarker, line = line_nr + #result.lines, col_start = fm_col_pos, col_end = line_len })
             table.insert(result.highlights, hltop)
         elseif ctx.show_guide_lines and symbol.level > 1 then
             line_add(

--- a/lua/symbols/init.lua
+++ b/lua/symbols/init.lua
@@ -1855,6 +1855,7 @@ end
 ---@param buf integer
 ---@param start_line integer zero-indexed
 ---@param details string[]
+---@param hl string
 local function buf_add_inline_details(buf, start_line, details, hl)
     for line, detail in ipairs(details) do
         vim.api.nvim_buf_set_extmark(


### PR DESCRIPTION
Hi,

Another proposal for some minor changes in rendering. 

* adds a new highlight definition to the `chars` type. `hl_foldmarker` defines the color for the top level fold markers.

* `hl_guides` is the renamed `chars.hl` to make its purpose more obvious. Used for the indent guidelines.

* `hl_details` to specify the color for the symbol details. I've put that outside of the `chars` type, because it may not belong there.

* use `vim.validate` to make sure the parameter to `api.action()` is a string

I've also found an issue that arises when moving a file to a different directory using a filetree plugin or oil while the file is open in a buffer. Symbols will disappear and refreshing may silently fail. The list just stays empty. I tried to fix this by invalidating the symbols in `Sidebar:refresh_view()` (using `symbols_retriever.cache[].fresh`), but that does not always work. I'm probably doing it the wrong way :)
